### PR TITLE
added missing function speex_header_free to libspeex.def

### DIFF
--- a/win32/libspeex.def
+++ b/win32/libspeex.def
@@ -61,6 +61,7 @@ speex_std_vbr_quality_request_handler
 speex_init_header
 speex_header_to_packet
 speex_packet_to_header
+speex_header_free
 
 ;
 ;	speex_stereo.h


### PR DESCRIPTION
libspeex.def is missing the function speex_header_free(), so library users on Visual Studio are not able to free speex_header structures, resulting in a (small) memory leak.