### PR TITLE
Fix vla detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_C_RESTRICT
 
 
 AC_MSG_CHECKING(for C99 variable-size arrays)
-+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
 int foo;
 foo = 10;
 int array[foo];


### PR DESCRIPTION
The tiny `+` seems to make the following test *always* succeed, breaking builds where variable-length arrays are unsupported (in particula MSVC).